### PR TITLE
added rules for hyphen in ids (along with tests and new error message)

### DIFF
--- a/ExCSS.Tests/SelectorFixture.cs
+++ b/ExCSS.Tests/SelectorFixture.cs
@@ -229,6 +229,53 @@ namespace ExCSS.Tests
         }
 
         [Test]
+        public void Parser_Reads_Id_Hyphen_Elements()
+        {
+            var parser = new Parser();
+            var css = parser.Parse("E#-id{}");
+
+            var rules = css.Rules;
+
+            Assert.AreEqual("E#-id{}", rules[0].ToString());
+        }
+
+        [Test]
+        public void Parser_Reads_Id_Multiple_Hyphen_Elements()
+        {
+            var parser = new Parser();
+            var css = parser.Parse("E#--id{}");
+
+            var rules = css.Rules;
+
+            Assert.AreEqual("E#--id{}", rules[0].ToString());
+            Assert.That(css.Errors.Count == 1);
+        }
+
+        [Test]
+        public void Parser_Reads_Id_Valid_Hyphen_Elements()
+        {
+            var parser = new Parser();
+            var css = parser.Parse("E#-_id{}");
+
+            var rules = css.Rules;
+
+            Assert.AreEqual("E#-_id{}", rules[0].ToString());
+            Assert.That(css.Errors.Count == 0);
+        }
+
+        [Test]
+        public void Parser_Reads_Id_Missing_Elements()
+        {
+            var parser = new Parser();
+            var css = parser.Parse("E#-{}");
+
+            var rules = css.Rules;
+
+            Assert.AreEqual("E#-{}", rules[0].ToString());
+            Assert.That(css.Errors.Count == 1);
+        }
+
+        [Test]
         public void Parser_Reads_Descendant_Elements()
         {
             var parser = new Parser();

--- a/ExCSS/Lexer.cs
+++ b/ExCSS/Lexer.cs
@@ -396,6 +396,16 @@ namespace ExCSS
         {
             if (current.IsNameStart() || current.IsDigit())
             {
+                if (current == Specification.MinusSign)
+                {
+                    char next = _stylesheetReader.Next;
+                    _stylesheetReader.Back();
+                    if (!next.IsLetter() && next != Specification.Underscore)
+                    {
+                        ErrorHandler(ParserError.InvalidCharacter, ErrorMessages.InvalidCharafterAfterHyphen);
+                    }
+                }
+
                 _buffer.Append(current);
                 return HashRest(_stylesheetReader.Next);
             }

--- a/ExCSS/Model/Enumerations.cs
+++ b/ExCSS/Model/Enumerations.cs
@@ -68,6 +68,7 @@ namespace ExCSS
 
     internal static class ErrorMessages
     {
+        internal const string InvalidCharafterAfterHyphen = "Expected a letter or an underscore after the first hyphen.";
         internal const string InvalidCharacter = "Invalid character detected.";
         internal const string LineBreakEof = "Unexpected line break or EOF.";
         internal const string UnexpectedCommentToken = "The input element is unexpected and has been ignored.";

--- a/ExCSS/Model/Specification.cs
+++ b/ExCSS/Model/Specification.cs
@@ -60,7 +60,7 @@
 
         internal static bool IsNameStart(this char c)
         {
-            return c >= 0x80 || IsUppercaseAscii(c) || IsLowercaseAscii(c) || c == Underscore;
+            return c >= 0x80 || IsUppercaseAscii(c) || IsLowercaseAscii(c) || c == Underscore || c == MinusSign;
         }
 
         internal static bool IsLineBreak(this char c)


### PR DESCRIPTION
This is a fix for case 909054 (https://fogbugz.unity3d.com/f/cases/909054)

According to CSS grammar (https://www.w3.org/TR/CSS21/grammar.html#scanner), ids should support hyphens in some conditions. I added them to the parser, along with according tests and error messages. 

